### PR TITLE
Update staff change message for helper rank

### DIFF
--- a/src/eu/beezig/core/briefing/lergin/StaffChangeType.java
+++ b/src/eu/beezig/core/briefing/lergin/StaffChangeType.java
@@ -22,8 +22,8 @@ package eu.beezig.core.briefing.lergin;
 public enum StaffChangeType {
 
 
-    MODERATOR_REMOVE("§cRetiring Moderators"),
-    MODERATOR_ADD("§cNew Moderators"),
+    MODERATOR_REMOVE("§cRetiring Moderators or Helpers"),
+    MODERATOR_ADD("§cNew Moderators or Helpers"),
     SENIOR_MODERATOR_REMOVE("§4Retiring Sr. Moderators"),
     SENIOR_MODERATOR_ADD("§4New Sr. Moderators"),
     NECTAR_REMOVE("§6Retiring Builders"),


### PR DESCRIPTION
The /staff endpoint groups moderators and helpers into one group so they are currently both published as new/former moderators
